### PR TITLE
Add test coverage badge

### DIFF
--- a/.github/workflows/api.yaml
+++ b/.github/workflows/api.yaml
@@ -51,6 +51,11 @@ jobs:
         env:
           ENVIRONMENT: development
 
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
   ruff:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/api.yaml
+++ b/.github/workflows/api.yaml
@@ -55,7 +55,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          working-directory: ./api
+          directory: ./api
 
   ruff:
     runs-on: ubuntu-latest

--- a/.github/workflows/api.yaml
+++ b/.github/workflows/api.yaml
@@ -55,6 +55,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          working-directory: ./api
 
   ruff:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # Deep Visualizer
 
+[![codecov](https://codecov.io/gh/florent-martineau/deep-visualizer/branch/main/graph/badge.svg)](https://codecov.io/gh/florent-martineau/deep-visualizer)
+
 TODO

--- a/api/.gitignore
+++ b/api/.gitignore
@@ -12,6 +12,7 @@ wheels/
 # Testing
 .mypy_cache
 .coverage
+coverage.xml
 
 # Environment variables
 .env*

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -43,10 +43,13 @@ pythonpath = [
 python_classes = ["*Test"]
 python_functions = ["should_*"]
 python_files = ["*_test.py"]
-addopts = ["--cov-report=xml"]
+addopts = ["--cov=.", "--cov-report=xml"]
 
 [tool.coverage.report]
-source=["."]
 fail_under = 93
 show_missing = true
 precision = 2
+
+
+[tool.coverage.xml]
+output = "coverage.xml"

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -43,6 +43,7 @@ pythonpath = [
 python_classes = ["*Test"]
 python_functions = ["should_*"]
 python_files = ["*_test.py"]
+addopts = ["--cov-report=xml"]
 
 [tool.coverage.report]
 source=["."]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Codecov badge to the README to display current test coverage status.

* **Chores**
  * CI now uploads test coverage reports to Codecov as part of the checks job.
  * Test tooling configured to produce an XML coverage report by default to support coverage uploads.
  * Coverage artifact file is ignored in version control.

Notes: No user-facing functionality changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->