### PR TITLE
Devboxes: add names

### DIFF
--- a/api/devbox.json
+++ b/api/devbox.json
@@ -1,4 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/0.16.0/.schema/devbox.schema.json",
-  "packages": ["uv@0.8"]
+  "packages": ["uv@0.8"],
+  "shell": {
+    "init_hook": "export PS1='[devbox-api] $ '"
+  }
 }

--- a/devbox.json
+++ b/devbox.json
@@ -1,4 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/0.16.0/.schema/devbox.schema.json",
-  "packages": ["uv@0.8"]
+  "packages": ["uv@0.8"],
+  "shell": {
+    "init_hook": "export PS1='[devbox-root] $ '"
+  }
 }

--- a/front/devbox.json
+++ b/front/devbox.json
@@ -1,4 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/0.16.0/.schema/devbox.schema.json",
-  "packages": ["bun@1.2"]
+  "packages": ["bun@1.2"],
+  "shell": {
+    "init_hook": "export PS1='[devbox-front] $ '"
+  }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Standardized Devbox shell prompts across environments for clearer context: “[devbox-root] $ ”, “[devbox-api] $ ”, and “[devbox-front] $ ” when starting respective shells.
  - Minor formatting adjustments in development configuration files; package lists remain unchanged.
  - No impact on application features or runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->