### PR TITLE
Opening a terminal at the root of the repo should not activate API's virtual environment

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -39,6 +39,7 @@
 			"source.organizeImports.ruff": "always"
 		}
 	},
+	"python.terminal.activateEnvironment": false,
 	"python.analysis.typeCheckingMode": "strict",
 	"python.analysis.autoImportCompletions": true,
 	"python.analysis.inlayHints.pytestParameters": true,


### PR DESCRIPTION
…

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated VS Code workspace settings to disable automatic activation of Python environments in the integrated terminal.
  * Terminals will now open without auto-activating a virtual environment; activate it manually (e.g., source/Activate) or override this behavior in your local settings if preferred.
  * This change affects only the editor experience and does not alter application runtime, builds, or tests.
  * Developers relying on auto-activation may need to adjust their local configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->