### PR TITLE
API: prefix routes with /api

### DIFF
--- a/api/constants.py
+++ b/api/constants.py
@@ -1,7 +1,12 @@
 from pathlib import Path
-from typing import Final
+from typing import Annotated, Final
+
+from pydantic import Field
 
 ACCESS_TOKEN_COOKIE_NAME: Final[str] = "access_token"
 ACCESS_TOKEN_COOKIE_HEADER: Final[str] = "X-Access-Token"
 API_BASE_PATH: Path = Path(__file__).parent
 OPENAPI_JSON_FILE_NAME: Final[str] = "openapi.json"
+API_PATH_PREFIX: Annotated[
+    Final[str], Field(description="Base path prefix for all API endpoints")
+] = "/api"

--- a/api/constants.py
+++ b/api/constants.py
@@ -7,6 +7,6 @@ ACCESS_TOKEN_COOKIE_NAME: Final[str] = "access_token"
 ACCESS_TOKEN_COOKIE_HEADER: Final[str] = "X-Access-Token"
 API_BASE_PATH: Path = Path(__file__).parent
 OPENAPI_JSON_FILE_NAME: Final[str] = "openapi.json"
-API_PATH_PREFIX: Annotated[
-    Final[str], Field(description="Base path prefix for all API endpoints")
+API_PATH_PREFIX: Final[
+    Annotated[str, Field(description="Base path prefix for all API endpoints")]
 ] = "/api"

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -5,11 +5,11 @@
     "version": "0.1.0"
   },
   "paths": {
-    "/access-token": {
+    "/api/access-token": {
       "post": {
         "summary": "Post Access Token",
         "description": "Stores HF Hub User Access Token as an httpOnly secure cookie.",
-        "operationId": "post_access_token_access_token_post",
+        "operationId": "post_access_token_api_access_token_post",
         "parameters": [
           {
             "name": "x-access-token",
@@ -45,7 +45,7 @@
       "delete": {
         "summary": "Delete Access Token",
         "description": "Deletes the HF Hub User Access Token stored as an httpOnly secure cookie.",
-        "operationId": "delete_access_token_access_token_delete",
+        "operationId": "delete_access_token_api_access_token_delete",
         "responses": {
           "204": {
             "description": "Successful Response"
@@ -55,7 +55,7 @@
       "get": {
         "summary": "Get Access Token",
         "description": "Checks whether the user has an HF Hub User Access Token stored as an httpOnly cookie, or not. It does **NOT** check the validity of this token. Validity is checked when setting up the cookie, and can be verified when the token is used.",
-        "operationId": "get_access_token_access_token_get",
+        "operationId": "get_access_token_api_access_token_get",
         "parameters": [
           {
             "name": "access_token",
@@ -93,11 +93,11 @@
         }
       }
     },
-    "/activation-function/{activation_function_name}": {
+    "/api/activation-function/{activation_function_name}": {
       "get": {
         "summary": "Get Activation Function",
         "description": "This function takes as input a range (min, max) and a step. For each value in this interval, it will apply the activation function, and return all the associated activations. This allows you to plot the activation function.",
-        "operationId": "get_activation_function_activation_function__activation_function_name__get",
+        "operationId": "get_activation_function_api_activation_function__activation_function_name__get",
         "parameters": [
           {
             "name": "activation_function_name",

--- a/api/routers/access_token.py
+++ b/api/routers/access_token.py
@@ -1,14 +1,15 @@
 from typing import Literal, Optional
 
-from fastapi import APIRouter, Cookie, Header, HTTPException, Response
+from fastapi import Cookie, Header, HTTPException, Response
 from huggingface_hub import HfApi
 from pydantic import BaseModel, Field
 from requests import HTTPError
 
 from api.constants import ACCESS_TOKEN_COOKIE_NAME
 from api.utils.logs import logger
+from api.utils.routers.router import getApiRouter
 
-router = APIRouter()
+router = getApiRouter(prefix="/access-token")
 
 
 class WhoAmIResponse(BaseModel):
@@ -34,7 +35,7 @@ class WhoAmIResponse(BaseModel):
 
 
 @router.post(
-    "/access-token",
+    path="",
     description="Stores HF Hub User Access Token as an httpOnly secure cookie.",
 )
 async def post_access_token(response: Response, x_access_token: str = Header()):
@@ -100,7 +101,7 @@ async def post_access_token(response: Response, x_access_token: str = Header()):
 
 
 @router.delete(
-    "/access-token",
+    path="",
     description="Deletes the HF Hub User Access Token "
     "stored as an httpOnly secure cookie.",
     status_code=204,
@@ -113,7 +114,7 @@ async def delete_access_token(response: Response):
 
 
 @router.get(
-    "/access-token",
+    path="",
     description="Checks whether the user has an HF Hub User Access Token "
     "stored as an httpOnly cookie, or not. It does **NOT** check the validity of "
     "this token. Validity is checked when setting up the cookie, and can be verified "

--- a/api/routers/access_token_test.py
+++ b/api/routers/access_token_test.py
@@ -12,7 +12,7 @@ from api.utils.env import test_settings
 class PostAccessTokenTest:
     def _make_post_request(self, token: str | None):
         headers = {ACCESS_TOKEN_COOKIE_HEADER: token} if token else {}
-        response = TestClient(app).post("/access-token", headers=headers)
+        response = TestClient(app).post("/api/access-token", headers=headers)
 
         if "Set-Cookie" in response.headers:
             cookie = SimpleCookie()
@@ -85,7 +85,7 @@ class DeleteAccessTokenTest:
                 ACCESS_TOKEN_COOKIE_NAME, test_settings().hf_access_token_fine_grained
             )
 
-        response = client.delete("/access-token")
+        response = client.delete("/api/access-token")
         return response
 
     @pytest.mark.parametrize(
@@ -117,7 +117,7 @@ class GetAccessTokenTest:
                 ACCESS_TOKEN_COOKIE_NAME, test_settings().hf_access_token_fine_grained
             )
 
-        response = client.get("/access-token")
+        response = client.get("/api/access-token")
         return response
 
     def should_return_204_if_cookie_is_present(self):

--- a/api/routers/core/activation_function.py
+++ b/api/routers/core/activation_function.py
@@ -7,10 +7,11 @@ from api.core.activation_function import (
     is_supported_activation,
 )
 from api.utils.logs import logger
-from fastapi import APIRouter, HTTPException, Path, Query
+from api.utils.routers.router import getApiRouter
+from fastapi import HTTPException, Path, Query
 from pydantic import BaseModel
 
-router = APIRouter()
+router = getApiRouter("/activation-function")
 
 # Maximum number of activations to be computed by the activation function route
 ACTIVATION_FUNCTION_ROUTE__MAX_ACTIVATIONS_TO_COMPUTE = 10_000
@@ -21,7 +22,7 @@ class ActivationFunctionResponse(BaseModel):
 
 
 @router.get(
-    "/activation-function/{activation_function_name}",
+    "/{activation_function_name}",
     description="This function takes as input a range (min, max) and a step. "
     "For each value in this interval, it will apply the activation function, "
     "and return all the associated activations. "

--- a/api/routers/core/activation_function_test.py
+++ b/api/routers/core/activation_function_test.py
@@ -33,7 +33,7 @@ def _make_request(
     if step is not None:
         params["step"] = step
 
-    response = client.get(f"/activation-function/{name}", params=params)
+    response = client.get(f"/api/activation-function/{name}", params=params)
     return response
 
 

--- a/api/utils/routers/router.py
+++ b/api/utils/routers/router.py
@@ -1,0 +1,8 @@
+from fastapi import APIRouter
+
+from api.constants import API_PATH_PREFIX
+
+
+def getApiRouter(prefix: str | None) -> APIRouter:
+    final_prefix = API_PATH_PREFIX if prefix is None else f"{API_PATH_PREFIX}{prefix}"
+    return APIRouter(prefix=final_prefix)

--- a/api/utils/routers/router_test.py
+++ b/api/utils/routers/router_test.py
@@ -1,0 +1,18 @@
+import pytest
+
+from api.constants import API_PATH_PREFIX
+from api.utils.routers.router import getApiRouter
+
+
+@pytest.mark.parametrize("prefix", ["foo", None])
+def should_be_correctly_prefixed(prefix: str | None):
+    router = getApiRouter(prefix=prefix)
+
+    if prefix is None:
+        assert router.prefix == API_PATH_PREFIX
+        return
+
+    assert router.prefix.startswith(API_PATH_PREFIX)
+    assert router.prefix.endswith(prefix)
+    assert len(router.prefix) == len(API_PATH_PREFIX) + len(prefix)
+    assert router.prefix == f"{API_PATH_PREFIX}{prefix}"

--- a/front/src/api.ts
+++ b/front/src/api.ts
@@ -53,7 +53,7 @@ export interface ValidationError {
   type: string;
 }
 
-export type GetActivationFunctionActivationFunctionActivationFunctionNameGetParams = {
+export type GetActivationFunctionApiActivationFunctionActivationFunctionNameGetParams = {
 /**
  * Minimum value to generate activations from.
  */
@@ -79,23 +79,23 @@ type AwaitedInput<T> = PromiseLike<T> | T;
  * Stores HF Hub User Access Token as an httpOnly secure cookie.
  * @summary Post Access Token
  */
-export const postAccessTokenAccessTokenPost = (
+export const postAccessTokenApiAccessTokenPost = (
      options?: AxiosRequestConfig
  ): Promise<AxiosResponse<unknown>> => {
     
     
     return axios.default.post(
-      `http://localhost:8000/access-token`,undefined,options
+      `http://localhost:8000/api/access-token`,undefined,options
     );
   }
 
 
 
-export const getPostAccessTokenAccessTokenPostMutationOptions = <TError = AxiosError<HTTPValidationError>,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof postAccessTokenAccessTokenPost>>, TError,void, TContext>, axios?: AxiosRequestConfig}
-): UseMutationOptions<Awaited<ReturnType<typeof postAccessTokenAccessTokenPost>>, TError,void, TContext> => {
+export const getPostAccessTokenApiAccessTokenPostMutationOptions = <TError = AxiosError<HTTPValidationError>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof postAccessTokenApiAccessTokenPost>>, TError,void, TContext>, axios?: AxiosRequestConfig}
+): UseMutationOptions<Awaited<ReturnType<typeof postAccessTokenApiAccessTokenPost>>, TError,void, TContext> => {
 
-const mutationKey = ['postAccessTokenAccessTokenPost'];
+const mutationKey = ['postAccessTokenApiAccessTokenPost'];
 const {mutation: mutationOptions, axios: axiosOptions} = options ?
       options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
       options
@@ -105,10 +105,10 @@ const {mutation: mutationOptions, axios: axiosOptions} = options ?
       
 
 
-      const mutationFn: MutationFunction<Awaited<ReturnType<typeof postAccessTokenAccessTokenPost>>, void> = () => {
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof postAccessTokenApiAccessTokenPost>>, void> = () => {
           
 
-          return  postAccessTokenAccessTokenPost(axiosOptions)
+          return  postAccessTokenApiAccessTokenPost(axiosOptions)
         }
 
         
@@ -116,23 +116,23 @@ const {mutation: mutationOptions, axios: axiosOptions} = options ?
 
   return  { mutationFn, ...mutationOptions }}
 
-    export type PostAccessTokenAccessTokenPostMutationResult = NonNullable<Awaited<ReturnType<typeof postAccessTokenAccessTokenPost>>>
+    export type PostAccessTokenApiAccessTokenPostMutationResult = NonNullable<Awaited<ReturnType<typeof postAccessTokenApiAccessTokenPost>>>
     
-    export type PostAccessTokenAccessTokenPostMutationError = AxiosError<HTTPValidationError>
+    export type PostAccessTokenApiAccessTokenPostMutationError = AxiosError<HTTPValidationError>
 
     /**
  * @summary Post Access Token
  */
-export const usePostAccessTokenAccessTokenPost = <TError = AxiosError<HTTPValidationError>,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof postAccessTokenAccessTokenPost>>, TError,void, TContext>, axios?: AxiosRequestConfig}
+export const usePostAccessTokenApiAccessTokenPost = <TError = AxiosError<HTTPValidationError>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof postAccessTokenApiAccessTokenPost>>, TError,void, TContext>, axios?: AxiosRequestConfig}
  ): UseMutationResult<
-        Awaited<ReturnType<typeof postAccessTokenAccessTokenPost>>,
+        Awaited<ReturnType<typeof postAccessTokenApiAccessTokenPost>>,
         TError,
         void,
         TContext
       > => {
 
-      const mutationOptions = getPostAccessTokenAccessTokenPostMutationOptions(options);
+      const mutationOptions = getPostAccessTokenApiAccessTokenPostMutationOptions(options);
 
       return useMutation(mutationOptions );
     }
@@ -141,23 +141,23 @@ export const usePostAccessTokenAccessTokenPost = <TError = AxiosError<HTTPValida
  * Deletes the HF Hub User Access Token stored as an httpOnly secure cookie.
  * @summary Delete Access Token
  */
-export const deleteAccessTokenAccessTokenDelete = (
+export const deleteAccessTokenApiAccessTokenDelete = (
      options?: AxiosRequestConfig
  ): Promise<AxiosResponse<void>> => {
     
     
     return axios.default.delete(
-      `http://localhost:8000/access-token`,options
+      `http://localhost:8000/api/access-token`,options
     );
   }
 
 
 
-export const getDeleteAccessTokenAccessTokenDeleteMutationOptions = <TError = AxiosError<unknown>,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof deleteAccessTokenAccessTokenDelete>>, TError,void, TContext>, axios?: AxiosRequestConfig}
-): UseMutationOptions<Awaited<ReturnType<typeof deleteAccessTokenAccessTokenDelete>>, TError,void, TContext> => {
+export const getDeleteAccessTokenApiAccessTokenDeleteMutationOptions = <TError = AxiosError<unknown>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof deleteAccessTokenApiAccessTokenDelete>>, TError,void, TContext>, axios?: AxiosRequestConfig}
+): UseMutationOptions<Awaited<ReturnType<typeof deleteAccessTokenApiAccessTokenDelete>>, TError,void, TContext> => {
 
-const mutationKey = ['deleteAccessTokenAccessTokenDelete'];
+const mutationKey = ['deleteAccessTokenApiAccessTokenDelete'];
 const {mutation: mutationOptions, axios: axiosOptions} = options ?
       options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
       options
@@ -167,10 +167,10 @@ const {mutation: mutationOptions, axios: axiosOptions} = options ?
       
 
 
-      const mutationFn: MutationFunction<Awaited<ReturnType<typeof deleteAccessTokenAccessTokenDelete>>, void> = () => {
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof deleteAccessTokenApiAccessTokenDelete>>, void> = () => {
           
 
-          return  deleteAccessTokenAccessTokenDelete(axiosOptions)
+          return  deleteAccessTokenApiAccessTokenDelete(axiosOptions)
         }
 
         
@@ -178,23 +178,23 @@ const {mutation: mutationOptions, axios: axiosOptions} = options ?
 
   return  { mutationFn, ...mutationOptions }}
 
-    export type DeleteAccessTokenAccessTokenDeleteMutationResult = NonNullable<Awaited<ReturnType<typeof deleteAccessTokenAccessTokenDelete>>>
+    export type DeleteAccessTokenApiAccessTokenDeleteMutationResult = NonNullable<Awaited<ReturnType<typeof deleteAccessTokenApiAccessTokenDelete>>>
     
-    export type DeleteAccessTokenAccessTokenDeleteMutationError = AxiosError<unknown>
+    export type DeleteAccessTokenApiAccessTokenDeleteMutationError = AxiosError<unknown>
 
     /**
  * @summary Delete Access Token
  */
-export const useDeleteAccessTokenAccessTokenDelete = <TError = AxiosError<unknown>,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof deleteAccessTokenAccessTokenDelete>>, TError,void, TContext>, axios?: AxiosRequestConfig}
+export const useDeleteAccessTokenApiAccessTokenDelete = <TError = AxiosError<unknown>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof deleteAccessTokenApiAccessTokenDelete>>, TError,void, TContext>, axios?: AxiosRequestConfig}
  ): UseMutationResult<
-        Awaited<ReturnType<typeof deleteAccessTokenAccessTokenDelete>>,
+        Awaited<ReturnType<typeof deleteAccessTokenApiAccessTokenDelete>>,
         TError,
         void,
         TContext
       > => {
 
-      const mutationOptions = getDeleteAccessTokenAccessTokenDeleteMutationOptions(options);
+      const mutationOptions = getDeleteAccessTokenApiAccessTokenDeleteMutationOptions(options);
 
       return useMutation(mutationOptions );
     }
@@ -203,54 +203,54 @@ export const useDeleteAccessTokenAccessTokenDelete = <TError = AxiosError<unknow
  * Checks whether the user has an HF Hub User Access Token stored as an httpOnly cookie, or not. It does **NOT** check the validity of this token. Validity is checked when setting up the cookie, and can be verified when the token is used.
  * @summary Get Access Token
  */
-export const getAccessTokenAccessTokenGet = (
+export const getAccessTokenApiAccessTokenGet = (
      options?: AxiosRequestConfig
  ): Promise<AxiosResponse<void>> => {
     
     
     return axios.default.get(
-      `http://localhost:8000/access-token`,options
+      `http://localhost:8000/api/access-token`,options
     );
   }
 
 
-export const getGetAccessTokenAccessTokenGetQueryKey = () => {
-    return [`http://localhost:8000/access-token`] as const;
+export const getGetAccessTokenApiAccessTokenGetQueryKey = () => {
+    return [`http://localhost:8000/api/access-token`] as const;
     }
 
     
-export const getGetAccessTokenAccessTokenGetQueryOptions = <TData = Awaited<ReturnType<typeof getAccessTokenAccessTokenGet>>, TError = AxiosError<HTTPValidationError>>( options?: { query?:UseQueryOptions<Awaited<ReturnType<typeof getAccessTokenAccessTokenGet>>, TError, TData>, axios?: AxiosRequestConfig}
+export const getGetAccessTokenApiAccessTokenGetQueryOptions = <TData = Awaited<ReturnType<typeof getAccessTokenApiAccessTokenGet>>, TError = AxiosError<HTTPValidationError>>( options?: { query?:UseQueryOptions<Awaited<ReturnType<typeof getAccessTokenApiAccessTokenGet>>, TError, TData>, axios?: AxiosRequestConfig}
 ) => {
 
 const {query: queryOptions, axios: axiosOptions} = options ?? {};
 
-  const queryKey =  queryOptions?.queryKey ?? getGetAccessTokenAccessTokenGetQueryKey();
+  const queryKey =  queryOptions?.queryKey ?? getGetAccessTokenApiAccessTokenGetQueryKey();
 
   
 
-    const queryFn: QueryFunction<Awaited<ReturnType<typeof getAccessTokenAccessTokenGet>>> = ({ signal }) => getAccessTokenAccessTokenGet({ signal, ...axiosOptions });
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof getAccessTokenApiAccessTokenGet>>> = ({ signal }) => getAccessTokenApiAccessTokenGet({ signal, ...axiosOptions });
 
       
 
       
 
-   return  { queryKey, queryFn, ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof getAccessTokenAccessTokenGet>>, TError, TData> & { queryKey: QueryKey }
+   return  { queryKey, queryFn, ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof getAccessTokenApiAccessTokenGet>>, TError, TData> & { queryKey: QueryKey }
 }
 
-export type GetAccessTokenAccessTokenGetQueryResult = NonNullable<Awaited<ReturnType<typeof getAccessTokenAccessTokenGet>>>
-export type GetAccessTokenAccessTokenGetQueryError = AxiosError<HTTPValidationError>
+export type GetAccessTokenApiAccessTokenGetQueryResult = NonNullable<Awaited<ReturnType<typeof getAccessTokenApiAccessTokenGet>>>
+export type GetAccessTokenApiAccessTokenGetQueryError = AxiosError<HTTPValidationError>
 
 
 /**
  * @summary Get Access Token
  */
 
-export function useGetAccessTokenAccessTokenGet<TData = Awaited<ReturnType<typeof getAccessTokenAccessTokenGet>>, TError = AxiosError<HTTPValidationError>>(
-  options?: { query?:UseQueryOptions<Awaited<ReturnType<typeof getAccessTokenAccessTokenGet>>, TError, TData>, axios?: AxiosRequestConfig}
+export function useGetAccessTokenApiAccessTokenGet<TData = Awaited<ReturnType<typeof getAccessTokenApiAccessTokenGet>>, TError = AxiosError<HTTPValidationError>>(
+  options?: { query?:UseQueryOptions<Awaited<ReturnType<typeof getAccessTokenApiAccessTokenGet>>, TError, TData>, axios?: AxiosRequestConfig}
   
  ):  UseQueryResult<TData, TError> & { queryKey: QueryKey } {
 
-  const queryOptions = getGetAccessTokenAccessTokenGetQueryOptions(options)
+  const queryOptions = getGetAccessTokenApiAccessTokenGetQueryOptions(options)
 
   const query = useQuery(queryOptions ) as  UseQueryResult<TData, TError> & { queryKey: QueryKey };
 
@@ -266,60 +266,60 @@ export function useGetAccessTokenAccessTokenGet<TData = Awaited<ReturnType<typeo
  * This function takes as input a range (min, max) and a step. For each value in this interval, it will apply the activation function, and return all the associated activations. This allows you to plot the activation function.
  * @summary Get Activation Function
  */
-export const getActivationFunctionActivationFunctionActivationFunctionNameGet = (
+export const getActivationFunctionApiActivationFunctionActivationFunctionNameGet = (
     activationFunctionName: string,
-    params: GetActivationFunctionActivationFunctionActivationFunctionNameGetParams, options?: AxiosRequestConfig
+    params: GetActivationFunctionApiActivationFunctionActivationFunctionNameGetParams, options?: AxiosRequestConfig
  ): Promise<AxiosResponse<ActivationFunctionResponse>> => {
     
     
     return axios.default.get(
-      `http://localhost:8000/activation-function/${activationFunctionName}`,{
+      `http://localhost:8000/api/activation-function/${activationFunctionName}`,{
     ...options,
         params: {...params, ...options?.params},}
     );
   }
 
 
-export const getGetActivationFunctionActivationFunctionActivationFunctionNameGetQueryKey = (activationFunctionName?: string,
-    params?: GetActivationFunctionActivationFunctionActivationFunctionNameGetParams,) => {
-    return [`http://localhost:8000/activation-function/${activationFunctionName}`, ...(params ? [params]: [])] as const;
+export const getGetActivationFunctionApiActivationFunctionActivationFunctionNameGetQueryKey = (activationFunctionName?: string,
+    params?: GetActivationFunctionApiActivationFunctionActivationFunctionNameGetParams,) => {
+    return [`http://localhost:8000/api/activation-function/${activationFunctionName}`, ...(params ? [params]: [])] as const;
     }
 
     
-export const getGetActivationFunctionActivationFunctionActivationFunctionNameGetQueryOptions = <TData = Awaited<ReturnType<typeof getActivationFunctionActivationFunctionActivationFunctionNameGet>>, TError = AxiosError<HTTPValidationError>>(activationFunctionName: string,
-    params: GetActivationFunctionActivationFunctionActivationFunctionNameGetParams, options?: { query?:UseQueryOptions<Awaited<ReturnType<typeof getActivationFunctionActivationFunctionActivationFunctionNameGet>>, TError, TData>, axios?: AxiosRequestConfig}
+export const getGetActivationFunctionApiActivationFunctionActivationFunctionNameGetQueryOptions = <TData = Awaited<ReturnType<typeof getActivationFunctionApiActivationFunctionActivationFunctionNameGet>>, TError = AxiosError<HTTPValidationError>>(activationFunctionName: string,
+    params: GetActivationFunctionApiActivationFunctionActivationFunctionNameGetParams, options?: { query?:UseQueryOptions<Awaited<ReturnType<typeof getActivationFunctionApiActivationFunctionActivationFunctionNameGet>>, TError, TData>, axios?: AxiosRequestConfig}
 ) => {
 
 const {query: queryOptions, axios: axiosOptions} = options ?? {};
 
-  const queryKey =  queryOptions?.queryKey ?? getGetActivationFunctionActivationFunctionActivationFunctionNameGetQueryKey(activationFunctionName,params);
+  const queryKey =  queryOptions?.queryKey ?? getGetActivationFunctionApiActivationFunctionActivationFunctionNameGetQueryKey(activationFunctionName,params);
 
   
 
-    const queryFn: QueryFunction<Awaited<ReturnType<typeof getActivationFunctionActivationFunctionActivationFunctionNameGet>>> = ({ signal }) => getActivationFunctionActivationFunctionActivationFunctionNameGet(activationFunctionName,params, { signal, ...axiosOptions });
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof getActivationFunctionApiActivationFunctionActivationFunctionNameGet>>> = ({ signal }) => getActivationFunctionApiActivationFunctionActivationFunctionNameGet(activationFunctionName,params, { signal, ...axiosOptions });
 
       
 
       
 
-   return  { queryKey, queryFn, enabled: !!(activationFunctionName), ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof getActivationFunctionActivationFunctionActivationFunctionNameGet>>, TError, TData> & { queryKey: QueryKey }
+   return  { queryKey, queryFn, enabled: !!(activationFunctionName), ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof getActivationFunctionApiActivationFunctionActivationFunctionNameGet>>, TError, TData> & { queryKey: QueryKey }
 }
 
-export type GetActivationFunctionActivationFunctionActivationFunctionNameGetQueryResult = NonNullable<Awaited<ReturnType<typeof getActivationFunctionActivationFunctionActivationFunctionNameGet>>>
-export type GetActivationFunctionActivationFunctionActivationFunctionNameGetQueryError = AxiosError<HTTPValidationError>
+export type GetActivationFunctionApiActivationFunctionActivationFunctionNameGetQueryResult = NonNullable<Awaited<ReturnType<typeof getActivationFunctionApiActivationFunctionActivationFunctionNameGet>>>
+export type GetActivationFunctionApiActivationFunctionActivationFunctionNameGetQueryError = AxiosError<HTTPValidationError>
 
 
 /**
  * @summary Get Activation Function
  */
 
-export function useGetActivationFunctionActivationFunctionActivationFunctionNameGet<TData = Awaited<ReturnType<typeof getActivationFunctionActivationFunctionActivationFunctionNameGet>>, TError = AxiosError<HTTPValidationError>>(
+export function useGetActivationFunctionApiActivationFunctionActivationFunctionNameGet<TData = Awaited<ReturnType<typeof getActivationFunctionApiActivationFunctionActivationFunctionNameGet>>, TError = AxiosError<HTTPValidationError>>(
  activationFunctionName: string,
-    params: GetActivationFunctionActivationFunctionActivationFunctionNameGetParams, options?: { query?:UseQueryOptions<Awaited<ReturnType<typeof getActivationFunctionActivationFunctionActivationFunctionNameGet>>, TError, TData>, axios?: AxiosRequestConfig}
+    params: GetActivationFunctionApiActivationFunctionActivationFunctionNameGetParams, options?: { query?:UseQueryOptions<Awaited<ReturnType<typeof getActivationFunctionApiActivationFunctionActivationFunctionNameGet>>, TError, TData>, axios?: AxiosRequestConfig}
   
  ):  UseQueryResult<TData, TError> & { queryKey: QueryKey } {
 
-  const queryOptions = getGetActivationFunctionActivationFunctionActivationFunctionNameGetQueryOptions(activationFunctionName,params,options)
+  const queryOptions = getGetActivationFunctionApiActivationFunctionActivationFunctionNameGetQueryOptions(activationFunctionName,params,options)
 
   const query = useQuery(queryOptions ) as  UseQueryResult<TData, TError> & { queryKey: QueryKey };
 

--- a/front/src/routes/activation-function.tsx
+++ b/front/src/routes/activation-function.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { useGetActivationFunctionActivationFunctionActivationFunctionNameGet } from "@/api";
+import { useGetActivationFunctionApiActivationFunctionActivationFunctionNameGet } from "@/api";
 
 export const Route = createFileRoute("/activation-function")({
 	component: ActivationFunction,
@@ -7,7 +7,7 @@ export const Route = createFileRoute("/activation-function")({
 
 function ActivationFunction() {
 	const { data } =
-		useGetActivationFunctionActivationFunctionActivationFunctionNameGet(
+		useGetActivationFunctionApiActivationFunctionActivationFunctionNameGet(
 			"gelu",
 			{ min: -1, max: 1, step: 0.5 },
 		);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Unified API namespace: all endpoints now use the /api prefix (e.g., /access-token → /api/access-token, /activation-function/{name} → /api/activation-function/{name]). OpenAPI spec updated. This is a breaking change—update client integrations.
- Refactor
  - Frontend API client, hooks and public types renamed to match the /api paths; update imports/usages if you consume these exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->