### PR TITLE
Rename ActivationFunction's name to id

### DIFF
--- a/api/core/activation_function.py
+++ b/api/core/activation_function.py
@@ -4,7 +4,7 @@ import torch
 from pydantic import BaseModel, ConfigDict, Field
 from transformers.activations import GELUActivation, NewGELUActivation
 
-ActivationFunctionName = Literal["gelu", "approximate-gelu", "silu"]
+ActivationFunctionId = Literal["gelu", "approximate-gelu", "silu"]
 
 
 class ActivationInputOutputPair(BaseModel):
@@ -23,8 +23,8 @@ class ActivationInputOutputPair(BaseModel):
 class ActivationFunction(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    name: Annotated[
-        ActivationFunctionName,
+    id: Annotated[
+        ActivationFunctionId,
         Field(description="Unique identifier for this activation function"),
     ]
     module: Annotated[
@@ -53,25 +53,25 @@ class ActivationFunction(BaseModel):
 
 
 _ACTIVATION_FUNCTIONS: List[ActivationFunction] = [
-    ActivationFunction(name="gelu", module=GELUActivation(), display_name="GELU"),
+    ActivationFunction(id="gelu", module=GELUActivation(), display_name="GELU"),
     ActivationFunction(
-        name="approximate-gelu",
+        id="approximate-gelu",
         module=NewGELUActivation(),
         display_name="Approximate GELU",
     ),
-    ActivationFunction(name="silu", module=torch.nn.SiLU(), display_name="SiLU"),
+    ActivationFunction(id="silu", module=torch.nn.SiLU(), display_name="SiLU"),
 ]
 
-ACTIVATION_FUNCTIONS: Dict[ActivationFunctionName, ActivationFunction] = {
-    activation_function.name: activation_function
+ACTIVATION_FUNCTIONS: Dict[ActivationFunctionId, ActivationFunction] = {
+    activation_function.id: activation_function
     for activation_function in _ACTIVATION_FUNCTIONS
 }
 
 
-SUPPORTED_ACTIVATION_FUNCTION_NAMES: tuple[ActivationFunctionName] = get_args(
-    ActivationFunctionName
+SUPPORTED_ACTIVATION_FUNCTION_IDS: tuple[ActivationFunctionId] = get_args(
+    ActivationFunctionId
 )
 
 
-def is_supported_activation(name: str) -> TypeGuard[ActivationFunctionName]:
-    return name in SUPPORTED_ACTIVATION_FUNCTION_NAMES
+def is_supported_activation(id: str) -> TypeGuard[ActivationFunctionId]:
+    return id in SUPPORTED_ACTIVATION_FUNCTION_IDS

--- a/api/core/activation_function_test.py
+++ b/api/core/activation_function_test.py
@@ -3,29 +3,29 @@ import pytest
 from api.core.activation_function import (
     _ACTIVATION_FUNCTIONS,  # type: ignore[reportPrivateUsage]
     ACTIVATION_FUNCTIONS,
-    SUPPORTED_ACTIVATION_FUNCTION_NAMES,
+    SUPPORTED_ACTIVATION_FUNCTION_IDS,
     is_supported_activation,
 )
 
 
 class IsSupportedActivationTypeGuardTest:
     @pytest.mark.parametrize(
-        "activation_function_name",
+        "activation_function_id",
         ["gelu_does_not_exist", "prefixed_gelu", "azertyuiop"],
     )
     def should_return_false_for_unsupported_activation_function(
-        self, activation_function_name: str
+        self, activation_function_id: str
     ):
-        assert not is_supported_activation(activation_function_name)
+        assert not is_supported_activation(activation_function_id)
 
     @pytest.mark.parametrize(
-        "activation_function_name",
-        SUPPORTED_ACTIVATION_FUNCTION_NAMES,
+        "activation_function_id",
+        SUPPORTED_ACTIVATION_FUNCTION_IDS,
     )
     def should_return_true_for_unsupported_activation_function(
-        self, activation_function_name: str
+        self, activation_function_id: str
     ):
-        assert is_supported_activation(activation_function_name)
+        assert is_supported_activation(activation_function_id)
 
 
 class ActivationFunctionsDictTest:
@@ -34,13 +34,13 @@ class ActivationFunctionsDictTest:
 
         expected_keys = set(
             map(
-                lambda activation_function: activation_function.name,
+                lambda activation_function: activation_function.id,
                 _ACTIVATION_FUNCTIONS,
             )
         )
         actual_keys = set(ACTIVATION_FUNCTIONS.keys())
         assert actual_keys == expected_keys
 
-    def should_have_the_object_name_match_the_key(self):
+    def should_have_the_object_id_match_the_key(self):
         for key, activation_function in ACTIVATION_FUNCTIONS.items():
-            assert key == activation_function.name
+            assert key == activation_function.id

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -93,27 +93,27 @@
         }
       }
     },
-    "/activation-function/{activation_function_name}": {
+    "/activation-function/{activation_function_id}": {
       "get": {
         "summary": "Get Activation Function",
         "description": "This function takes as input a range (min, max) and a step. For each value in this interval, it will apply the activation function, and return all the associated activations. This allows you to plot the activation function.",
-        "operationId": "Get_Activation_Function_activation_function__activation_function_name__get",
+        "operationId": "get_activation_function_activation_function__activation_function_id__get",
         "parameters": [
           {
-            "name": "activation_function_name",
+            "name": "activation_function_id",
             "in": "path",
             "required": true,
             "schema": {
               "type": "string",
-              "description": "Name of the activation function",
+              "description": "Id of the activation function",
               "examples": [
                 "gelu",
-                "gelu_new",
+                "approximate-gelu",
                 "silu"
               ],
-              "title": "Activation Function Name"
+              "title": "Activation Function Id"
             },
-            "description": "Name of the activation function"
+            "description": "Id of the activation function"
           },
           {
             "name": "min",

--- a/api/routers/core/activation_function.py
+++ b/api/routers/core/activation_function.py
@@ -2,7 +2,7 @@ from typing import List, Set
 
 from api.core.activation_function import (
     ACTIVATION_FUNCTIONS,
-    SUPPORTED_ACTIVATION_FUNCTION_NAMES,
+    SUPPORTED_ACTIVATION_FUNCTION_IDS,
     ActivationInputOutputPair,
     is_supported_activation,
 )
@@ -22,7 +22,7 @@ class ActivationFunctionResponse(BaseModel):
 
 
 @router.get(
-    "/{activation_function_name}",
+    "/{activation_function_id}",
     description="This function takes as input a range (min, max) and a step. "
     "For each value in this interval, it will apply the activation function, "
     "and return all the associated activations. "
@@ -31,9 +31,9 @@ class ActivationFunctionResponse(BaseModel):
     response_model=ActivationFunctionResponse,
 )
 async def get_activation_function(
-    activation_function_name: str = Path(
-        description="Name of the activation function",
-        examples=list(SUPPORTED_ACTIVATION_FUNCTION_NAMES),
+    activation_function_id: str = Path(
+        description="Id of the activation function",
+        examples=list(SUPPORTED_ACTIVATION_FUNCTION_IDS),
     ),
     min: float = Query(description="Minimum value to generate activations from."),
     max: float = Query(description="Maximum value to generate activations from."),
@@ -46,21 +46,21 @@ async def get_activation_function(
     logger.info(
         "Retrieving activation function",
         extra={
-            "activation_function": activation_function_name,
+            "activation_function": activation_function_id,
             "min": min,
             "max": max,
             "step": step,
         },
     )
 
-    if not is_supported_activation(activation_function_name):
+    if not is_supported_activation(activation_function_id):
         raise HTTPException(
             status_code=404,
-            detail=f"Activation function '{activation_function_name}' not found. "
-            f"Valid functions are: {', '.join(SUPPORTED_ACTIVATION_FUNCTION_NAMES)}",
+            detail=f"Activation function '{activation_function_id}' not found. "
+            f"Valid functions are: {', '.join(SUPPORTED_ACTIVATION_FUNCTION_IDS)}",
         )
 
-    activation_function = ACTIVATION_FUNCTIONS[activation_function_name]
+    activation_function = ACTIVATION_FUNCTIONS[activation_function_id]
 
     if min >= max:
         raise HTTPException(

--- a/front/src/api.ts
+++ b/front/src/api.ts
@@ -267,42 +267,42 @@ export function useGetAccessToken<TData = Awaited<ReturnType<typeof GetAccessTok
  * @summary Get Activation Function
  */
 export const GetActivationFunction = (
-    activationFunctionName: string,
+    activationFunctionId: string,
     params: GetActivationFunctionParams, options?: AxiosRequestConfig
  ): Promise<AxiosResponse<ActivationFunctionResponse>> => {
     
     
     return axios.default.get(
-      `/activation-function/${activationFunctionName}`,{
+      `/activation-function/${activationFunctionId}`,{
     ...options,
         params: {...params, ...options?.params},}
     );
   }
 
 
-export const getGetActivationFunctionQueryKey = (activationFunctionName?: string,
+export const getGetActivationFunctionQueryKey = (activationFunctionId?: string,
     params?: GetActivationFunctionParams,) => {
-    return [`/activation-function/${activationFunctionName}`, ...(params ? [params]: [])] as const;
+    return [`/activation-function/${activationFunctionId}`, ...(params ? [params]: [])] as const;
     }
 
     
-export const getGetActivationFunctionQueryOptions = <TData = Awaited<ReturnType<typeof GetActivationFunction>>, TError = AxiosError<HTTPValidationError>>(activationFunctionName: string,
+export const getGetActivationFunctionQueryOptions = <TData = Awaited<ReturnType<typeof GetActivationFunction>>, TError = AxiosError<HTTPValidationError>>(activationFunctionId: string,
     params: GetActivationFunctionParams, options?: { query?:UseQueryOptions<Awaited<ReturnType<typeof GetActivationFunction>>, TError, TData>, axios?: AxiosRequestConfig}
 ) => {
 
 const {query: queryOptions, axios: axiosOptions} = options ?? {};
 
-  const queryKey =  queryOptions?.queryKey ?? getGetActivationFunctionQueryKey(activationFunctionName,params);
+  const queryKey =  queryOptions?.queryKey ?? getGetActivationFunctionQueryKey(activationFunctionId,params);
 
   
 
-    const queryFn: QueryFunction<Awaited<ReturnType<typeof GetActivationFunction>>> = ({ signal }) => GetActivationFunction(activationFunctionName,params, { signal, ...axiosOptions });
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof GetActivationFunction>>> = ({ signal }) => GetActivationFunction(activationFunctionId,params, { signal, ...axiosOptions });
 
       
 
       
 
-   return  { queryKey, queryFn, enabled: !!(activationFunctionName), ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof GetActivationFunction>>, TError, TData> & { queryKey: QueryKey }
+   return  { queryKey, queryFn, enabled: !!(activationFunctionId), ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof GetActivationFunction>>, TError, TData> & { queryKey: QueryKey }
 }
 
 export type GetActivationFunctionQueryResult = NonNullable<Awaited<ReturnType<typeof GetActivationFunction>>>
@@ -314,12 +314,12 @@ export type GetActivationFunctionQueryError = AxiosError<HTTPValidationError>
  */
 
 export function useGetActivationFunction<TData = Awaited<ReturnType<typeof GetActivationFunction>>, TError = AxiosError<HTTPValidationError>>(
- activationFunctionName: string,
+ activationFunctionId: string,
     params: GetActivationFunctionParams, options?: { query?:UseQueryOptions<Awaited<ReturnType<typeof GetActivationFunction>>, TError, TData>, axios?: AxiosRequestConfig}
   
  ):  UseQueryResult<TData, TError> & { queryKey: QueryKey } {
 
-  const queryOptions = getGetActivationFunctionQueryOptions(activationFunctionName,params,options)
+  const queryOptions = getGetActivationFunctionQueryOptions(activationFunctionId,params,options)
 
   const query = useQuery(queryOptions ) as  UseQueryResult<TData, TError> & { queryKey: QueryKey };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Replaced activation function “name” with “id” across backend and frontend. Endpoint now uses /activation-function/{activation_function_id}; client queries/hooks accept activationFunctionId.
- Documentation
  - OpenAPI updated: parameter renamed to activation_function_id with revised descriptions and examples (e.g., “approximate-gelu”).
- Tests
  - Updated to validate id-based identifiers throughout.

Note: Existing integrations should switch to using activation function IDs in paths and parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->