### PR TITLE
Rename Front's /api to /api-proxy

### DIFF
--- a/front/src/api.ts
+++ b/front/src/api.ts
@@ -85,7 +85,7 @@ export const PostAccessToken = (
     
     
     return axios.default.post(
-      `/access-token`,undefined,options
+      `/api-proxy/access-token`,undefined,options
     );
   }
 
@@ -147,7 +147,7 @@ export const DeleteAccessToken = (
     
     
     return axios.default.delete(
-      `/access-token`,options
+      `/api-proxy/access-token`,options
     );
   }
 
@@ -209,7 +209,7 @@ export const GetAccessToken = (
     
     
     return axios.default.get(
-      `/access-token`,options
+      `/api-proxy/access-token`,options
     );
   }
 
@@ -218,7 +218,7 @@ export const GetAccessToken = (
 
 export const getGetAccessTokenQueryKey = () => {
     return [
-    `/access-token`
+    `/api-proxy/access-token`
     ] as const;
     }
 
@@ -277,7 +277,7 @@ export const GetActivationFunction = (
     
     
     return axios.default.get(
-      `/activation-function/${activationFunctionId}`,{
+      `/api-proxy/activation-function/${activationFunctionId}`,{
     ...options,
         params: {...params, ...options?.params},}
     );
@@ -289,7 +289,7 @@ export const GetActivationFunction = (
 export const getGetActivationFunctionQueryKey = (activationFunctionId?: string,
     params?: GetActivationFunctionParams,) => {
     return [
-    `/activation-function/${activationFunctionId}`, ...(params ? [params]: [])
+    `/api-proxy/activation-function/${activationFunctionId}`, ...(params ? [params]: [])
     ] as const;
     }
 

--- a/front/src/routeTree.gen.ts
+++ b/front/src/routeTree.gen.ts
@@ -9,7 +9,7 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
-import { Route as ApiRouteImport } from './routes/api'
+import { Route as ApiProxyRouteImport } from './routes/api-proxy'
 import { Route as ActivationFunctionRouteImport } from './routes/activation-function'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as DemoTanstackQueryRouteImport } from './routes/demo.tanstack-query'
@@ -23,9 +23,9 @@ import { Route as DemoStartApiRequestRouteImport } from './routes/demo.start.api
 import { Route as DemoFormSimpleRouteImport } from './routes/demo.form.simple'
 import { Route as DemoFormAddressRouteImport } from './routes/demo.form.address'
 
-const ApiRoute = ApiRouteImport.update({
-  id: '/api',
-  path: '/api',
+const ApiProxyRoute = ApiProxyRouteImport.update({
+  id: '/api-proxy',
+  path: '/api-proxy',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ActivationFunctionRoute = ActivationFunctionRouteImport.update({
@@ -59,14 +59,14 @@ const DemoMcpTodosRoute = DemoMcpTodosRouteImport.update({
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiDemoTqTodosRoute = ApiDemoTqTodosRouteImport.update({
-  id: '/demo-tq-todos',
-  path: '/demo-tq-todos',
-  getParentRoute: () => ApiRoute,
+  id: '/api/demo-tq-todos',
+  path: '/api/demo-tq-todos',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const ApiDemoNamesRoute = ApiDemoNamesRouteImport.update({
-  id: '/demo-names',
-  path: '/demo-names',
-  getParentRoute: () => ApiRoute,
+  id: '/api/demo-names',
+  path: '/api/demo-names',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const DemoStartServerFuncsRoute = DemoStartServerFuncsRouteImport.update({
   id: '/demo/start/server-funcs',
@@ -92,7 +92,7 @@ const DemoFormAddressRoute = DemoFormAddressRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/activation-function': typeof ActivationFunctionRoute
-  '/api': typeof ApiRouteWithChildren
+  '/api-proxy': typeof ApiProxyRoute
   '/api/demo-names': typeof ApiDemoNamesRoute
   '/api/demo-tq-todos': typeof ApiDemoTqTodosRoute
   '/demo/mcp-todos': typeof DemoMcpTodosRoute
@@ -107,7 +107,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/activation-function': typeof ActivationFunctionRoute
-  '/api': typeof ApiRouteWithChildren
+  '/api-proxy': typeof ApiProxyRoute
   '/api/demo-names': typeof ApiDemoNamesRoute
   '/api/demo-tq-todos': typeof ApiDemoTqTodosRoute
   '/demo/mcp-todos': typeof DemoMcpTodosRoute
@@ -123,7 +123,7 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/activation-function': typeof ActivationFunctionRoute
-  '/api': typeof ApiRouteWithChildren
+  '/api-proxy': typeof ApiProxyRoute
   '/api/demo-names': typeof ApiDemoNamesRoute
   '/api/demo-tq-todos': typeof ApiDemoTqTodosRoute
   '/demo/mcp-todos': typeof DemoMcpTodosRoute
@@ -140,7 +140,7 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/activation-function'
-    | '/api'
+    | '/api-proxy'
     | '/api/demo-names'
     | '/api/demo-tq-todos'
     | '/demo/mcp-todos'
@@ -155,7 +155,7 @@ export interface FileRouteTypes {
   to:
     | '/'
     | '/activation-function'
-    | '/api'
+    | '/api-proxy'
     | '/api/demo-names'
     | '/api/demo-tq-todos'
     | '/demo/mcp-todos'
@@ -170,7 +170,7 @@ export interface FileRouteTypes {
     | '__root__'
     | '/'
     | '/activation-function'
-    | '/api'
+    | '/api-proxy'
     | '/api/demo-names'
     | '/api/demo-tq-todos'
     | '/demo/mcp-todos'
@@ -186,7 +186,9 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   ActivationFunctionRoute: typeof ActivationFunctionRoute
-  ApiRoute: typeof ApiRouteWithChildren
+  ApiProxyRoute: typeof ApiProxyRoute
+  ApiDemoNamesRoute: typeof ApiDemoNamesRoute
+  ApiDemoTqTodosRoute: typeof ApiDemoTqTodosRoute
   DemoMcpTodosRoute: typeof DemoMcpTodosRoute
   DemoStoreRoute: typeof DemoStoreRoute
   DemoTableRoute: typeof DemoTableRoute
@@ -199,11 +201,11 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    '/api': {
-      id: '/api'
-      path: '/api'
-      fullPath: '/api'
-      preLoaderRoute: typeof ApiRouteImport
+    '/api-proxy': {
+      id: '/api-proxy'
+      path: '/api-proxy'
+      fullPath: '/api-proxy'
+      preLoaderRoute: typeof ApiProxyRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/activation-function': {
@@ -250,17 +252,17 @@ declare module '@tanstack/react-router' {
     }
     '/api/demo-tq-todos': {
       id: '/api/demo-tq-todos'
-      path: '/demo-tq-todos'
+      path: '/api/demo-tq-todos'
       fullPath: '/api/demo-tq-todos'
       preLoaderRoute: typeof ApiDemoTqTodosRouteImport
-      parentRoute: typeof ApiRoute
+      parentRoute: typeof rootRouteImport
     }
     '/api/demo-names': {
       id: '/api/demo-names'
-      path: '/demo-names'
+      path: '/api/demo-names'
       fullPath: '/api/demo-names'
       preLoaderRoute: typeof ApiDemoNamesRouteImport
-      parentRoute: typeof ApiRoute
+      parentRoute: typeof rootRouteImport
     }
     '/demo/start/server-funcs': {
       id: '/demo/start/server-funcs'
@@ -293,22 +295,12 @@ declare module '@tanstack/react-router' {
   }
 }
 
-interface ApiRouteChildren {
-  ApiDemoNamesRoute: typeof ApiDemoNamesRoute
-  ApiDemoTqTodosRoute: typeof ApiDemoTqTodosRoute
-}
-
-const ApiRouteChildren: ApiRouteChildren = {
-  ApiDemoNamesRoute: ApiDemoNamesRoute,
-  ApiDemoTqTodosRoute: ApiDemoTqTodosRoute,
-}
-
-const ApiRouteWithChildren = ApiRoute._addFileChildren(ApiRouteChildren)
-
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   ActivationFunctionRoute: ActivationFunctionRoute,
-  ApiRoute: ApiRouteWithChildren,
+  ApiProxyRoute: ApiProxyRoute,
+  ApiDemoNamesRoute: ApiDemoNamesRoute,
+  ApiDemoTqTodosRoute: ApiDemoTqTodosRoute,
   DemoMcpTodosRoute: DemoMcpTodosRoute,
   DemoStoreRoute: DemoStoreRoute,
   DemoTableRoute: DemoTableRoute,

--- a/front/src/routes/api-proxy.ts
+++ b/front/src/routes/api-proxy.ts
@@ -12,6 +12,8 @@ const proxy = async ({ request }: { request: Request }) => {
 	const headers = new Headers(request.headers);
 	headers.set("host", env.API_HOST);
 
+	newUrl.pathname = newUrl.pathname.replace(/^\/api-proxy/, "");
+
 	const response = await fetch(newUrl, {
 		method: request.method,
 		headers,
@@ -25,7 +27,7 @@ const proxy = async ({ request }: { request: Request }) => {
 	});
 };
 
-export const Route = createFileRoute("/api")({
+export const Route = createFileRoute("/api-proxy")({
 	server: {
 		handlers: {
 			ALL: proxy,

--- a/orval.config.ts
+++ b/orval.config.ts
@@ -7,6 +7,7 @@ export const getOrvalConfig: (target: string) => Config = (target) => ({
     output: {
       target,
       client: 'react-query',
+      baseUrl: '/api-proxy',
       override: {
         operationName: (operation) => {
           return (operation.summary ?? '').replaceAll(' ', '');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a new /api-proxy route that transparently forwards API requests.
  - App URLs for API-related pages now live under /api-proxy.

- Refactor
  - Renamed the public API route to align with the new /api-proxy path.
  - Updated internal routing and query key paths to match the new prefix.

- Chores
  - Updated API client configuration to use /api-proxy as the base URL.
  - Regenerated route and type definitions to reflect the new path structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->