### PR TITLE
API route: rename activation-function to activation-functions

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -93,11 +93,11 @@
         }
       }
     },
-    "/activation-function/{activation_function_id}": {
+    "/activation-functions/{activation_function_id}": {
       "get": {
         "summary": "Get Activation Function",
         "description": "This function takes as input a range (min, max) and a step. For each value in this interval, it will apply the activation function, and return all the associated activations. This allows you to plot the activation function.",
-        "operationId": "get_activation_function_activation_function__activation_function_id__get",
+        "operationId": "get_activation_function_activation_functions__activation_function_id__get",
         "parameters": [
           {
             "name": "activation_function_id",

--- a/api/routers/core/activation_function.py
+++ b/api/routers/core/activation_function.py
@@ -11,7 +11,7 @@ from api.utils.routers.router import getApiRouter
 from fastapi import HTTPException, Path, Query
 from pydantic import BaseModel
 
-router = getApiRouter("/activation-function")
+router = getApiRouter("/activation-functions")
 
 # Maximum number of activations to be computed by the activation function route
 ACTIVATION_FUNCTION_ROUTE__MAX_ACTIVATIONS_TO_COMPUTE = 10_000

--- a/api/routers/core/activation_function_test.py
+++ b/api/routers/core/activation_function_test.py
@@ -34,7 +34,7 @@ def _make_request(
     if step is not None:
         params["step"] = step
 
-    response = client.get(f"{API_PATH_PREFIX}/activation-function/{id}", params=params)
+    response = client.get(f"{API_PATH_PREFIX}/activation-functions/{id}", params=params)
     return response
 
 

--- a/front/src/api.ts
+++ b/front/src/api.ts
@@ -277,7 +277,7 @@ export const GetActivationFunction = (
     
     
     return axios.default.get(
-      `/api-proxy/activation-function/${activationFunctionId}`,{
+      `/api-proxy/activation-functions/${activationFunctionId}`,{
     ...options,
         params: {...params, ...options?.params},}
     );
@@ -289,7 +289,7 @@ export const GetActivationFunction = (
 export const getGetActivationFunctionQueryKey = (activationFunctionId?: string,
     params?: GetActivationFunctionParams,) => {
     return [
-    `/api-proxy/activation-function/${activationFunctionId}`, ...(params ? [params]: [])
+    `/api-proxy/activation-functions/${activationFunctionId}`, ...(params ? [params]: [])
     ] as const;
     }
 

--- a/front/src/components/Header.tsx
+++ b/front/src/components/Header.tsx
@@ -1,5 +1,5 @@
 import { Link } from "@tanstack/react-router";
 
 export default function Header() {
-	return <Link to="/activation-function">Activation Function</Link>;
+	return <Link to="/activation-functions">Activation Function</Link>;
 }

--- a/front/src/routeTree.gen.ts
+++ b/front/src/routeTree.gen.ts
@@ -10,7 +10,7 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as ApiProxyRouteImport } from './routes/api-proxy'
-import { Route as ActivationFunctionRouteImport } from './routes/activation-function'
+import { Route as ActivationFunctionsRouteImport } from './routes/activation-functions'
 import { Route as IndexRouteImport } from './routes/index'
 
 const ApiProxyRoute = ApiProxyRouteImport.update({
@@ -18,9 +18,9 @@ const ApiProxyRoute = ApiProxyRouteImport.update({
   path: '/api-proxy',
   getParentRoute: () => rootRouteImport,
 } as any)
-const ActivationFunctionRoute = ActivationFunctionRouteImport.update({
-  id: '/activation-function',
-  path: '/activation-function',
+const ActivationFunctionsRoute = ActivationFunctionsRouteImport.update({
+  id: '/activation-functions',
+  path: '/activation-functions',
   getParentRoute: () => rootRouteImport,
 } as any)
 const IndexRoute = IndexRouteImport.update({
@@ -31,31 +31,31 @@ const IndexRoute = IndexRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
-  '/activation-function': typeof ActivationFunctionRoute
+  '/activation-functions': typeof ActivationFunctionsRoute
   '/api-proxy': typeof ApiProxyRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
-  '/activation-function': typeof ActivationFunctionRoute
+  '/activation-functions': typeof ActivationFunctionsRoute
   '/api-proxy': typeof ApiProxyRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
-  '/activation-function': typeof ActivationFunctionRoute
+  '/activation-functions': typeof ActivationFunctionsRoute
   '/api-proxy': typeof ApiProxyRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/activation-function' | '/api-proxy'
+  fullPaths: '/' | '/activation-functions' | '/api-proxy'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/activation-function' | '/api-proxy'
-  id: '__root__' | '/' | '/activation-function' | '/api-proxy'
+  to: '/' | '/activation-functions' | '/api-proxy'
+  id: '__root__' | '/' | '/activation-functions' | '/api-proxy'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
-  ActivationFunctionRoute: typeof ActivationFunctionRoute
+  ActivationFunctionsRoute: typeof ActivationFunctionsRoute
   ApiProxyRoute: typeof ApiProxyRoute
 }
 
@@ -68,11 +68,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiProxyRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/activation-function': {
-      id: '/activation-function'
-      path: '/activation-function'
-      fullPath: '/activation-function'
-      preLoaderRoute: typeof ActivationFunctionRouteImport
+    '/activation-functions': {
+      id: '/activation-functions'
+      path: '/activation-functions'
+      fullPath: '/activation-functions'
+      preLoaderRoute: typeof ActivationFunctionsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/': {
@@ -87,7 +87,7 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
-  ActivationFunctionRoute: ActivationFunctionRoute,
+  ActivationFunctionsRoute: ActivationFunctionsRoute,
   ApiProxyRoute: ApiProxyRoute,
 }
 export const routeTree = rootRouteImport

--- a/front/src/routes/activation-functions.tsx
+++ b/front/src/routes/activation-functions.tsx
@@ -7,7 +7,7 @@ import {
 	useGetActivationFunction,
 } from "@/api";
 
-export const Route = createFileRoute("/activation-function")({
+export const Route = createFileRoute("/activation-functions")({
 	component: ActivationFunction,
 });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized API endpoint and UI route from “/activation-function” to “/activation-functions”.
  * Updated public API operation identifier to reflect the new path.
  * Aligned frontend query keys and navigation links with the pluralized route.
  * Regenerated route typings and mappings to use the new path.
  * Note: API clients and bookmarks must update to the new URL.

* **Tests**
  * Updated tests to target the new “/activation-functions/{id}” route.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->